### PR TITLE
Troubleshoot msi admin installation error

### DIFF
--- a/installers/MSI_PACKAGING_README.md
+++ b/installers/MSI_PACKAGING_README.md
@@ -239,7 +239,28 @@ The `wix-setup.wxs` file can be customized for:
 
 ### Common Issues
 
-1. **WiX Toolset Not Found**:
+1. **Admin Error During Installation (MOST COMMON)**:
+   - **Symptoms**: "Administrator privileges required" error even when logged in as admin
+   - **Cause**: UAC (User Account Control) blocking MSI installation or missing InstallPrivileges
+   - **Solutions**:
+     - Use the provided PowerShell installer: `installers\install-msi-admin.ps1`
+     - Right-click MSI file → "Run as administrator"
+     - Command line: `msiexec /i RoboBackupTool-1.0.0.0.msi /quiet /l*v install.log`
+     - Ensure UAC is enabled (counter-intuitive but required for proper elevation)
+
+2. **"Run as Administrator" Option Missing**:
+   - Add registry entry to enable context menu option:
+   ```cmd
+   reg add "HKEY_CLASSES_ROOT\Msi.Package\shell\runas" /ve /d "Install as &Administrator" /f
+   reg add "HKEY_CLASSES_ROOT\Msi.Package\shell\runas\command" /ve /d "msiexec /i \"%%1\"" /f
+   ```
+
+3. **UAC Completely Blocking Installation**:
+   - Temporarily lower UAC settings in Control Panel → User Accounts
+   - Use PowerShell with `-ExecutionPolicy Bypass`
+   - Contact IT administrator for group policy exceptions
+
+4. **WiX Toolset Not Found**:
    - Ensure WiX is installed and in PATH
    - Verify installation: `candle.exe --version`
 

--- a/installers/build-msi.bat
+++ b/installers/build-msi.bat
@@ -6,14 +6,20 @@ echo RoboBackup Tool MSI Installer Builder
 echo ========================================
 
 :: Check if WiX Toolset is installed
-set "WIX_PATH=C:\Program Files\WiX Toolset v6.0\bin"
+set "WIX_PATH=C:\Program Files\WiX Toolset v4.0\bin"
 if not exist "%WIX_PATH%\wix.exe" (
-    echo ERROR: WiX Toolset v6.0 not found at %WIX_PATH%!
-    echo Please install WiX Toolset v6.0 from: https://wixtoolset.org/releases/
-    pause
-    exit /b 1
+    set "WIX_PATH=C:\Program Files\WiX Toolset v6.0\bin"
+    if not exist "%WIX_PATH%\wix.exe" (
+        echo ERROR: WiX Toolset not found!
+        echo Please install WiX Toolset v4.0 or v6.0 from: https://wixtoolset.org/releases/
+        echo Note: This MSI requires WiX v4+ for proper UAC handling
+        pause
+        exit /b 1
+    )
+    echo WiX Toolset v6.0 found at: %WIX_PATH%
+) else (
+    echo WiX Toolset v4.0 found at: %WIX_PATH%
 )
-echo WiX Toolset v6.0 found at: %WIX_PATH%
 
 :: Check if PyInstaller is available
 where pyinstaller.exe >nul 2>&1
@@ -125,6 +131,18 @@ echo - Desktop shortcut
 echo - Automatic service installation and startup
 echo.
 echo To install, run the MSI file as Administrator.
+echo.
+echo IMPORTANT INSTALLATION NOTES:
+echo ========================================
+echo 1. Right-click the MSI file and select "Run as administrator"
+echo 2. If UAC prompt appears, click "Yes" to allow installation
+echo 3. For silent installation: msiexec /i RoboBackupTool-%VERSION%.msi /quiet
+echo 4. For enterprise deployment, use: msiexec /i RoboBackupTool-%VERSION%.msi /quiet /norestart
+echo.
+echo Common Issues:
+echo - "Admin error" despite being admin: Use "Run as administrator" context menu
+echo - UAC blocking: Ensure UAC is enabled and click "Yes" when prompted
+echo - Group Policy restrictions: Contact IT administrator
 echo.
 
 :: Clean up temporary files

--- a/installers/install-msi-admin.ps1
+++ b/installers/install-msi-admin.ps1
@@ -1,0 +1,140 @@
+# RoboBackup Tool MSI Admin Installer
+# This script ensures proper admin installation of the MSI package
+
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$MsiPath,
+    
+    [Parameter(Mandatory=$false)]
+    [switch]$Silent = $false,
+    
+    [Parameter(Mandatory=$false)]
+    [string]$LogFile = "install.log"
+)
+
+function Test-AdminPrivileges {
+    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentUser)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Find-MsiFile {
+    $scriptDir = Split-Path -Parent $MyInvocation.ScriptName
+    $distDir = Join-Path (Split-Path -Parent $scriptDir) "dist"
+    
+    # Look for MSI files in common locations
+    $searchPaths = @(
+        $scriptDir,
+        $distDir,
+        (Get-Location).Path
+    )
+    
+    foreach ($path in $searchPaths) {
+        $msiFiles = Get-ChildItem -Path $path -Filter "RoboBackupTool*.msi" -ErrorAction SilentlyContinue
+        if ($msiFiles) {
+            return $msiFiles[0].FullName
+        }
+    }
+    
+    return $null
+}
+
+function Install-MsiAsAdmin {
+    param(
+        [string]$MsiFilePath,
+        [bool]$SilentInstall,
+        [string]$LogFilePath
+    )
+    
+    Write-Host "Installing RoboBackup Tool MSI..." -ForegroundColor Green
+    Write-Host "MSI File: $MsiFilePath" -ForegroundColor Gray
+    
+    # Build msiexec arguments
+    $arguments = @("/i", "`"$MsiFilePath`"")
+    
+    if ($SilentInstall) {
+        $arguments += "/quiet"
+        $arguments += "/norestart"
+        Write-Host "Silent installation mode" -ForegroundColor Gray
+    }
+    
+    # Add logging
+    $arguments += "/l*v"
+    $arguments += "`"$LogFilePath`""
+    
+    try {
+        Write-Host "Executing: msiexec.exe $($arguments -join ' ')" -ForegroundColor Gray
+        $process = Start-Process -FilePath "msiexec.exe" -ArgumentList $arguments -Wait -PassThru -Verb RunAs
+        
+        if ($process.ExitCode -eq 0) {
+            Write-Host "Installation completed successfully!" -ForegroundColor Green
+            Write-Host "The RoboBackup service has been installed and started." -ForegroundColor Green
+            return $true
+        } else {
+            Write-Host "Installation failed with exit code: $($process.ExitCode)" -ForegroundColor Red
+            
+            # Common exit codes
+            switch ($process.ExitCode) {
+                1603 { Write-Host "Error 1603: Fatal error during installation" -ForegroundColor Red }
+                1619 { Write-Host "Error 1619: This installation package could not be opened" -ForegroundColor Red }
+                1620 { Write-Host "Error 1620: This installation package could not be opened" -ForegroundColor Red }
+                1633 { Write-Host "Error 1633: This installation package is not supported on this platform" -ForegroundColor Red }
+                default { Write-Host "See log file for details: $LogFilePath" -ForegroundColor Yellow }
+            }
+            return $false
+        }
+    } catch {
+        Write-Host "Error executing installer: $($_.Exception.Message)" -ForegroundColor Red
+        return $false
+    }
+}
+
+# Main execution
+Write-Host "RoboBackup Tool MSI Admin Installer" -ForegroundColor Cyan
+Write-Host "=====================================" -ForegroundColor Cyan
+
+# Check admin privileges
+if (-not (Test-AdminPrivileges)) {
+    Write-Host "ERROR: This script must be run as Administrator!" -ForegroundColor Red
+    Write-Host "Please right-click and select 'Run as Administrator'" -ForegroundColor Yellow
+    Read-Host "Press Enter to exit"
+    exit 1
+}
+
+Write-Host "Running with Administrator privileges ✓" -ForegroundColor Green
+
+# Find MSI file if not specified
+if (-not $MsiPath) {
+    Write-Host "Searching for MSI file..." -ForegroundColor Gray
+    $MsiPath = Find-MsiFile
+    
+    if (-not $MsiPath) {
+        Write-Host "ERROR: Could not find RoboBackupTool MSI file!" -ForegroundColor Red
+        Write-Host "Please specify the path using: -MsiPath 'path\to\RoboBackupTool.msi'" -ForegroundColor Yellow
+        Read-Host "Press Enter to exit"
+        exit 1
+    }
+    
+    Write-Host "Found MSI: $MsiPath" -ForegroundColor Green
+}
+
+# Verify MSI file exists
+if (-not (Test-Path $MsiPath)) {
+    Write-Host "ERROR: MSI file not found: $MsiPath" -ForegroundColor Red
+    Read-Host "Press Enter to exit"
+    exit 1
+}
+
+# Install MSI
+$success = Install-MsiAsAdmin -MsiFilePath $MsiPath -SilentInstall $Silent -LogFilePath $LogFile
+
+if ($success) {
+    Write-Host "`nInstallation completed successfully!" -ForegroundColor Green
+    Write-Host "You can now run RoboBackup Tool from the Start Menu." -ForegroundColor Green
+} else {
+    Write-Host "`nInstallation failed. Check the log file: $LogFile" -ForegroundColor Red
+}
+
+if (-not $Silent) {
+    Read-Host "`nPress Enter to exit"
+}

--- a/installers/wix-setup.wxs
+++ b/installers/wix-setup.wxs
@@ -5,7 +5,9 @@
              Manufacturer="RoboBackup Development Team"
              UpgradeCode="dddb19d1-da76-4e5b-9b63-a92b2204c4a4"
              Language="1033"
-             Compressed="yes">
+             Compressed="yes"
+             InstallPrivileges="elevated"
+             InstallScope="perMachine">
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of RoboBackup Tool is already installed." />
     
@@ -137,6 +139,13 @@
     
     <!-- UI Properties -->
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
+    
+    <!-- UAC and Admin Properties -->
+    <Property Id="MSIUSEREALADMINDETECTION" Value="1" />
+    <Property Id="ALLUSERS" Value="1" />
+    
+    <!-- UI Reference for standard installation dialogs -->
+    <UIRef Id="WixUI_InstallDir" />
     
     </Package>
 </Wix>


### PR DESCRIPTION
Configure MSI installer for proper admin elevation and provide a PowerShell script to resolve installation privilege errors.

The MSI installation was failing with admin errors due to missing privilege declarations in the WiX setup and UAC interactions. This PR adds necessary WiX configurations and introduces a PowerShell script to ensure the installer runs with elevated privileges.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cbad7a8-436c-46ff-83d5-724fbd681fb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cbad7a8-436c-46ff-83d5-724fbd681fb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

